### PR TITLE
Searches-Controller implemented

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,4 +1,24 @@
 class SearchesController < ApplicationController
+  skip_before_action :verify_authenticity_token # Skip CSRF token verification for API requests
+
+  SESSION_TIMEOUT = 5.minutes # Define the session timeout duration
   def create
+    user_ip = request.remote_ip # Get the user's IP address
+    query_text = params[:query] # Get the search query from the request parameters
+    return head :ok if query_text.blank? # Do not process if the query is blank
+
+    # Find the last "active" search for the same IP
+    last_search = Search.where(ip: user_ip)
+                        .where("last_seen_at > ?", SESSION_TIMEOUT.ago)
+                        .order(last_seen_at: :desc)
+                        .first
+
+    if last_search && query_text.start_with?(last_search.query) # Check if the new query starts with the last query
+      last_search.update(query: query_text, last_seen_at: Time.current) # Update the last search with the new query and timestamp
+    else
+      Search.create(query: query_text, ip: user_ip, last_seen_at: Time.current) # Create a new search record
+    end
+
+    head :ok # Respond with a 200 OK status
   end
 end


### PR DESCRIPTION
This pull request introduces enhancements to the `SearchesController` to improve search tracking functionality and streamline API requests. The most notable changes include implementing session timeout logic for search tracking, handling blank queries gracefully, and skipping CSRF token verification for API requests.

### Search tracking improvements:

* Added logic to track user searches based on IP address and session timeout. If a new query starts with the last active query within the session timeout, the existing search record is updated; otherwise, a new search record is created. (`app/controllers/searches_controller.rb`, [app/controllers/searches_controller.rbR2-R22](diffhunk://#diff-b8f829c906439ddf15f11f1d3c26a93cf538f739dff9e107d46df8768de16aacR2-R22))
* Defined a `SESSION_TIMEOUT` constant to set the session timeout duration to 5 minutes. (`app/controllers/searches_controller.rb`, [app/controllers/searches_controller.rbR2-R22](diffhunk://#diff-b8f829c906439ddf15f11f1d3c26a93cf538f739dff9e107d46df8768de16aacR2-R22))

### API request handling:

* Added `skip_before_action :verify_authenticity_token` to bypass CSRF token verification for API requests. (`app/controllers/searches_controller.rb`, [app/controllers/searches_controller.rbR2-R22](diffhunk://#diff-b8f829c906439ddf15f11f1d3c26a93cf538f739dff9e107d46df8768de16aacR2-R22))
* Implemented a check to return a `200 OK` response without processing if the search query is blank. (`app/controllers/searches_controller.rb`, [app/controllers/searches_controller.rbR2-R22](diffhunk://#diff-b8f829c906439ddf15f11f1d3c26a93cf538f739dff9e107d46df8768de16aacR2-R22))