### PR TITLE
Pyramid problem fixed

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -6,9 +6,9 @@ class SearchesController < ApplicationController
   def create
     query_text = I18n.transliterate(params[:query].to_s)
                       .downcase
-                      .gsub(/[[:punct:]]/, "")
+                      .gsub(/[[:punct:]]/, '')
                       .strip
-                      .squeeze(" ")
+                      .squeeze(' ')
 
     return head :ok if query_text.blank?
 


### PR DESCRIPTION
This pull request makes minor adjustments to the `SearchesController` to improve code consistency by standardizing the use of single quotes in string literals.

* [`app/controllers/searches_controller.rb`](diffhunk://#diff-b8f829c906439ddf15f11f1d3c26a93cf538f739dff9e107d46df8768de16aacL9-R11): Replaced double quotes with single quotes in the `gsub` and `squeeze` methods for improved consistency in string formatting.